### PR TITLE
chore(README): fix missing password manager reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Experience and tutorials on divers subjects
 ## Security
 
 * [Using GPG](security/cryptography/gpg.md)
+* [Password manager with GPG](security/cryptography/pass.md)


### PR DESCRIPTION
Just reference the `pass` markdown in the main tables contents